### PR TITLE
Add: Custom search per version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changelog
 - Added freshdesk to html template [svx]
 - Improved CSS for code-block [staeff] [svx]
 - Nav items should break line if neccessary [staeff]
+- Add custom search [svx]
 
 0.1.1 (26/06/2014)
 ------------------

--- a/src/sphinx/themes/plone/plone_basic/layout.html
+++ b/src/sphinx/themes/plone/plone_basic/layout.html
@@ -125,6 +125,7 @@
   {% endfor %}
 
   <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
 
   {%- block linktags %}
     {%- if hasdoc('about') %}

--- a/src/sphinx/themes/plone/plone_basic/layout.html
+++ b/src/sphinx/themes/plone/plone_basic/layout.html
@@ -280,7 +280,7 @@
 <!-- Below block includes custom search per version -->
 <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
 <script type="text/javascript"> docsearch({
-  apiKey: 'HEREOURAPIKEY',
+  apiKey: '7ab1cfcbe98c5ba873049f48e18ac2a3',
   indexName: 'plone',
   inputSelector: '#rtd-search-form input[name="q"]',
   algoliaOptions: { 'facetFilters': ["tags:{{ theme_selected_version }}"] },

--- a/src/sphinx/themes/plone/plone_basic/layout.html
+++ b/src/sphinx/themes/plone/plone_basic/layout.html
@@ -282,7 +282,7 @@
   apiKey: 'HEREOURAPIKEY',
   indexName: 'plone',
   inputSelector: '#rtd-search-form input[name="q"]',
-  algoliaOptions: { 'facetFilters': ["tags:'{{ search_version }}'"] },
+  algoliaOptions: { 'facetFilters': ["tags:{{ theme_selected_version }}"] },
   debug: false // Set debug to true if you want to inspect the dropdown
 });
 </script>

--- a/src/sphinx/themes/plone/plone_basic/layout.html
+++ b/src/sphinx/themes/plone/plone_basic/layout.html
@@ -276,6 +276,18 @@
 </script>
 {%- endif %}
 
+<!-- Below block includes custom search per version -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+  apiKey: 'HEREOURAPIKEY',
+  indexName: 'plone',
+  inputSelector: '#rtd-search-form input[name="q"]',
+  algoliaOptions: { 'facetFilters': ["tags:{{ search_version }}"] },
+  debug: false // Set debug to true if you want to inspect the dropdown
+});
+</script>
+
+
 {% endblock %}
 
 </body>

--- a/src/sphinx/themes/plone/plone_basic/layout.html
+++ b/src/sphinx/themes/plone/plone_basic/layout.html
@@ -277,17 +277,15 @@
 {%- endif %}
 
 <!-- Below block includes custom search per version -->
-{%- if theme_use_algolia %}
 <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
 <script type="text/javascript"> docsearch({
   apiKey: 'HEREOURAPIKEY',
   indexName: 'plone',
   inputSelector: '#rtd-search-form input[name="q"]',
-  algoliaOptions: { 'facetFilters': ["tags:{{ search_version }}"] },
+  algoliaOptions: { 'facetFilters': ["tags:'{{ search_version }}'"] },
   debug: false // Set debug to true if you want to inspect the dropdown
 });
 </script>
-{%- endif %}
 
 
 {% endblock %}

--- a/src/sphinx/themes/plone/plone_basic/layout.html
+++ b/src/sphinx/themes/plone/plone_basic/layout.html
@@ -277,6 +277,7 @@
 {%- endif %}
 
 <!-- Below block includes custom search per version -->
+{%- if theme_use_algolia %}
 <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
 <script type="text/javascript"> docsearch({
   apiKey: 'HEREOURAPIKEY',
@@ -286,6 +287,7 @@
   debug: false // Set debug to true if you want to inspect the dropdown
 });
 </script>
+{%- endif %}
 
 
 {% endblock %}


### PR DESCRIPTION
@loechel @polyester 

I am trying to add the new custom search to the docs, for this we need a new setting in the conf.py.
As you cab see I added a new js script to the layout template, would that now wrok with a new setting in the conf.py ?

Something like:
```
search_version = '5'
```
Would that generate html output like this:
```
....
algoliaOptions: { 'facetFilters': ["tags:5"] },
...
```
?

Thanks !