### PR TITLE
add tag manager code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changelog
 - Improved CSS for code-block [staeff] [svx]
 - Nav items should break line if neccessary [staeff]
 - Add custom search [svx]
+- Add tagmanager code [polyester]
 
 0.1.1 (26/06/2014)
 ------------------

--- a/src/sphinx/themes/plone/plone_basic/layout.html
+++ b/src/sphinx/themes/plone/plone_basic/layout.html
@@ -110,6 +110,14 @@
     <link type="image/x-icon" href="{{ pathto('_static/' + theme_favicon, 1) }}" />
   {% endif %}
 
+  <!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-KLDW8HG');</script>
+<!-- End Google Tag Manager -->
+
   <script type="text/javascript" src="{{ pathto('_static/jquery.js', 1) }}"></script>
 
   {# OPENSEARCH #}
@@ -160,6 +168,11 @@
 </head>
 
 <body role="document">
+
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KLDW8HG"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
 
 {% include "topbar.html" %}
 {% include "header.html" %}


### PR DESCRIPTION
this is to include google tagmanager, to make use of the google-adword grant the Foundation has; same code is now in place on plone.org, and we have someone with knowledge on how to optimize this volunteering to optimize our use of that grant.