### PR TITLE
Add Header bar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 - Update doormat (footer), fix typos in Advanced Usage [tkimnguyen]
 - Change color of 'support widget' to match with plone.org
 - change links color and underline for acessibility and better visibility [svx,polyester]
+- Add Header
 
 0.1.1 (26/06/2014)
 ------------------

--- a/src/sphinx/themes/plone/plone_basic/layout.html
+++ b/src/sphinx/themes/plone/plone_basic/layout.html
@@ -25,7 +25,7 @@
       <div class="col-xs-9">
         <div role="navigation" aria-label="breadcrumbs navigation">
           <ul class="breadcrumb">
-            {#<li><a href="http://plone.org">Plone</a></li>#}
+            {#<li><a href="https://plone.org">Plone</a></li>#}
             <li class="master">
               {% if theme_always_show_version_switcher or (theme_version_switcher and version|length > 1) %}
                 <span class="version_switcher">

--- a/src/sphinx/themes/plone/plone_basic/static/css/plone_basic.css
+++ b/src/sphinx/themes/plone/plone_basic/static/css/plone_basic.css
@@ -402,3 +402,58 @@ a.internal code {
     text-decoration: none;
 }
 
+/* Custom for Plone Header Bar */
+.topbar{
+font-size: 11px;
+font-weight: 600;
+text-transform: uppercase;
+background: #1f1238;
+width: 100%;
+overflow: hidden;
+border-bottom: 1px solid black;
+}
+.topcontainer{
+margin-right: auto;
+margin-left: auto;
+padding-left: 15px;
+padding-right: 15px
+}
+@media (min-width: 968px){
+.topcontainer{
+  width: 750px;
+  }
+}
+@media (min-width: 992px){
+.topcontainer{
+  width: 970px;
+  }
+}
+@media (min-width: 1200px){
+.topcontainer{
+  width: 1170px;
+  }
+}
+.topbar ul{
+  margin-right: 2.5em;
+  float: right;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.topbar ul li{
+  float: left;
+}
+.topbar a{
+color: #e5e5e5;
+text-decoration: none;
+padding: 7px 8px 5px 8px;
+line-height: 11px;
+display: inline-block;
+font-family: Roboto, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+font-size: 11px;
+font-weight: 600;
+}
+.topbar a:hover{
+color: #fff;
+background: #2a184b;
+}

--- a/src/sphinx/themes/plone/plone_basic/topbar.html
+++ b/src/sphinx/themes/plone/plone_basic/topbar.html
@@ -1,4 +1,30 @@
 {% block topbar %}
+<div class="topbar">
+            <div class="topcontainer">
+              <ul id="links-select">
+                <li>
+                  <a href="https://plone.org" title="PLONE.ORG">
+                    plone.org
+                  </a>
+                </li>
+                <li>
+                  <a href="http://plone.com" title="PLONE.COM">
+                    plone.com
+                  </a>
+                </li>
+                <li>
+                  <a href="http://training.plone.org" title="TRAINING.PLONE.ORG">
+                    training.plone.org
+                  </a>
+                </li>
+                <li>
+                  <a href="http://docs.plone.org" title="DOCS.PLONE.ORG">
+                    docs.plone.org
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
 {% if theme_external_topbar %}
 <div id="topbar" class="navbar navbar-inverse navbar-static-top">
   <div class="container" id="topbarcontainer">

--- a/src/sphinx/themes/plone/plone_basic/topbar.html
+++ b/src/sphinx/themes/plone/plone_basic/topbar.html
@@ -4,22 +4,27 @@
               <ul id="links-select">
                 <li>
                   <a href="https://plone.org" title="PLONE.ORG">
-                    plone.org
+                    PLONE.ORG
                   </a>
                 </li>
                 <li>
-                  <a href="http://plone.com" title="PLONE.COM">
-                    plone.com
+                  <a href="https://plone.com" title="PLONE.COM">
+                    PLONE.COM
                   </a>
                 </li>
                 <li>
-                  <a href="http://training.plone.org" title="TRAINING.PLONE.ORG">
-                    training.plone.org
+                  <a href="https://training.plone.org" title="TRAINING.PLONE.ORG">
+                    TRAINING.PLONE.ORG
                   </a>
                 </li>
                 <li>
-                  <a href="http://docs.plone.org" title="DOCS.PLONE.ORG">
-                    docs.plone.org
+                  <a href="https://docs.plone.org" title="DOCS.PLONE.ORG">
+                    DOCS.PLONE.ORG
+                  </a>
+                </li>
+                <li>
+                  <a href="https://community.plone.org" title="COMMUNITY.PLONE.ORG">
+                    COMMUNITY.PLONE.ORG
                   </a>
                 </li>
               </ul>


### PR DESCRIPTION
This adds the 'header bar' as we already use it on training.plone.org and community.plone.org to docs.plone.org

![docs_with_header](https://cloud.githubusercontent.com/assets/358860/23455038/976e4d0c-fe6e-11e6-9d43-dac89300c468.png)
