### PR TITLE
remove the aside toggle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changelog
 - change links color and underline for accessibility and better visibility [svx,polyester]
 - Add Topbar Header for cross navigation [svx,loechel]
 - Fix Accessibility Issue with title tags in Topbar [loechel]
+- Remove Aside toggle preperation [loechel]
 
 0.1.1 (26/06/2014)
 ------------------

--- a/src/sphinx/themes/plone/plone_basic/layout.html
+++ b/src/sphinx/themes/plone/plone_basic/layout.html
@@ -187,7 +187,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     {%- endif %}
     <div class="row">
     <aside class="col-sm-4 col-lg-3 hidden-xs">
-      <div class="aside-toggle"></div>
       <div class="sidebarwrapper">
         {# SIDE NAV, TOGGLES ON MOBILE #}
         <nav data-toggle="nav-shift" class="nav-side">


### PR DESCRIPTION
remove the aside toggle that causes a fail color element in the right navigation.

this was a planned feature that was never finalized. 

this fix #54.